### PR TITLE
Add keepalive job to scheduled workflows

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -59,3 +59,11 @@ jobs:
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH
           ./.deploy.sh
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -70,3 +70,11 @@ jobs:
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH
           pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
Add workflow-keepalive job to cron.yml and archive.yml to prevent GitHub from automatically disabling scheduled workflows after 60 days of inactivity.